### PR TITLE
fixing compile error with Mathf.Clamp

### DIFF
--- a/Assets/GameLogic/GameController.cs
+++ b/Assets/GameLogic/GameController.cs
@@ -210,6 +210,11 @@ namespace ThirdEyeSoftware.GameLogic
             set;
         }
 
+        private void OnProductsConvertedHandler(List<ProductInfoViewModel> productsForUI)
+        {
+
+        }
+
         public void ProgressToNextLevel()
         {
             if (CurLevel.SubLevel < Constants.Levels.NumSubLevels)

--- a/Assets/GameLogic/GameController.cs
+++ b/Assets/GameLogic/GameController.cs
@@ -20,6 +20,7 @@ namespace ThirdEyeSoftware.GameLogic
         void ProgressToNextLevel();
         bool JustBeatMaxLevel { get; }
         bool JustSavedLatestLevel { get; set; }
+        List<ProductInfoViewModel> ProductsForUI { get; set; }
     }
 
     public class ScoreInfo
@@ -119,7 +120,7 @@ namespace ThirdEyeSoftware.GameLogic
         private ILogicHandler _gameLogicHandler;
         private ILogicHandler _menuLogicHandler;
         public bool ShouldUpdate { get; set; }
-
+        public List<ProductInfoViewModel> ProductsForUI { get; set; } = new List<ProductInfoViewModel>();
 
         public static GameController Instance
         {

--- a/Assets/GameLogic/GameLogic.csproj
+++ b/Assets/GameLogic/GameLogic.csproj
@@ -42,9 +42,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files\Unity\Hub\Editor\2019.1.11f1\Editor\Data\Managed\UnityEngine\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="LogicHandlers\BaseLogicHandler.cs" />

--- a/Assets/GameLogic/Interfaces.cs
+++ b/Assets/GameLogic/Interfaces.cs
@@ -2,6 +2,8 @@
 using System.Collections;
 using ThirdEyeSoftware.GameLogic.LogicHandlers;
 using GameLogic.Utils;
+using ThirdEyeSoftware.GameLogic.StoreLogicService;
+using System.Collections.Generic;
 
 namespace ThirdEyeSoftware.GameLogic
 {
@@ -160,6 +162,7 @@ namespace ThirdEyeSoftware.GameLogic
         Action OnPurchaseFailedEventHandler { get; set; }
         Action<string> OnPurchaseSucceededEventHandler { get; set; }
         Action<string> LogToDebugOutput { get; set; }
+        Action<List<ProductInfo>> OnAppStoreInitialized { get; set; }
     }
 
     public interface IProductInfo

--- a/Assets/GameLogic/LogicImplementers/AsteroidPlacementLogicImplementer.cs
+++ b/Assets/GameLogic/LogicImplementers/AsteroidPlacementLogicImplementer.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text;
 using ThirdEyeSoftware.GameLogic;
 using ThirdEyeSoftware.GameLogic.Utils;
-using UnityEngine;
 
 namespace GameLogic.LogicImplementers
 {
@@ -248,7 +247,17 @@ namespace GameLogic.LogicImplementers
                 minDistance = 0 + (ASTEROID_WIDTH/2f); //first asteroid can be all the way up to the left edge of the screen, but not hanging off the edge
                 var screenWidth = X_MAX - X_MIN;
                 var clampMax = screenWidth - (ASTEROID_WIDTH / 2f);
-                maxDistance = Mathf.Clamp(maxDistance, minDistance, clampMax); //by clamping here (instead of after we've returned, clamped asteroids will not always be at the right edge of the screen)
+
+                //clamp maxDistance between clampMax and minDistance
+                //by clamping here (instead of after we've returned, clamped asteroids will not always be at the right edge of the screen)
+                if (maxDistance > clampMax)
+                { 
+                    maxDistance = clampMax;
+                }
+                else if(maxDistance < minDistance)
+                {
+                    maxDistance = minDistance;
+                }
 
                 retVal = _initialRandomGenrator.GetRandomValue(minDistance, maxDistance);
             }

--- a/Assets/GameLogic/LogicProviders/MenuLogicProviders/GetMoreLivesLogicProvider.cs
+++ b/Assets/GameLogic/LogicProviders/MenuLogicProviders/GetMoreLivesLogicProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using ThirdEyeSoftware.GameLogic;
 using ThirdEyeSoftware.GameLogic.LogicHandlers;
 using ThirdEyeSoftware.GameLogic.LogicProviders;
@@ -8,12 +9,25 @@ namespace GameLogic.LogicProviders.MenuLogicProviders
 {
     public class GetMoreLivesLogicProvider : BaseLogicProvider
     {
+        class ProductUIControls
+        {
+            public IText ButtonLabel { get; set; }
+            public IText SavePctLabel { get; set; }
+
+            public ProductUIControls(IText buttonLabel, IText savePctLabel)
+            {
+                ButtonLabel = buttonLabel;
+                SavePctLabel = savePctLabel;
+            }
+        }
+
         private IGameObject _pnlGetMoreLives;
         private IGameObject _btnCancel;
         private IGameObject _btnBuyLivesSmall;
         private IGameObject _btnBuyLivesMedium;
         private IGameObject _btnBuyLivesLarge;
         private IText _txtCurrentLives;
+        Dictionary<string, ProductUIControls> _productTextBoxMapping = new Dictionary<string, ProductUIControls>();
 
         public GetMoreLivesLogicProvider(ILogicHandler logicHandler, IGameEngineInterface gameEngineInterface, IDataLayer dataLayer)
             : base(logicHandler, gameEngineInterface, dataLayer)
@@ -81,10 +95,22 @@ namespace GameLogic.LogicProviders.MenuLogicProviders
 
             var txtCurrentLivesGameObject = _gameEngineInterface.FindGameObject("txtCurrentLives");
             _txtCurrentLives = txtCurrentLivesGameObject.GetComponent<IText>();
-            
+
+            _populateProductTextBoxMapping();
 
             _pnlGetMoreLives = _gameEngineInterface.FindGameObject("pnlGetMoreLives");
             _pnlGetMoreLives.SetActive(false);
+        }
+
+        private void _populateProductTextBoxMapping()
+        {
+            var txtSavePctSmall = _gameEngineInterface.FindGameObject("txtBuyLivesSmallSavePct").GetComponent<IText>();
+            var txtSavePctMedium = _gameEngineInterface.FindGameObject("txtBuyLivesMediumSavePct").GetComponent<IText>();
+            var txtSavePctLarge = _gameEngineInterface.FindGameObject("txtBuyLivesLargeSavePct").GetComponent<IText>();
+
+            _productTextBoxMapping[Constants.ProductNames.BuyLivesSmall] = new ProductUIControls(_btnBuyLivesSmall.GetComponent<IText>(), txtSavePctSmall);
+            _productTextBoxMapping[Constants.ProductNames.BuyLivesMedium] = new ProductUIControls(_btnBuyLivesMedium.GetComponent<IText>(), txtSavePctMedium);
+            _productTextBoxMapping[Constants.ProductNames.BuyLivesLarge] = new ProductUIControls(_btnBuyLivesLarge.GetComponent<IText>(), txtSavePctLarge);
         }
 
         public override void OnActivate()
@@ -92,6 +118,35 @@ namespace GameLogic.LogicProviders.MenuLogicProviders
             _pnlGetMoreLives.SetActive(true);
 
             _txtCurrentLives.Text = "REMAINING LIVES: " + _dataLayer.GetNumLivesRemaining();
+
+            SetPriceLabels(_logicHandler.GameController.ProductsForUI);
+        }
+
+        //todo: this List should have really been a dictionary, keyed by product ID
+        private void SetPriceLabels(List<ProductInfoViewModel> products)
+        {
+            if(products == null || products.Count == 0)
+            {
+                LogToDebugOutput("Could not load products from Google Play store. Please try again later.");
+            }
+            else
+            {
+                var buttonTextFormatString = @"{0}
+ LIVES 
+{1}";
+                var smallProduct = products.Single(x => x.ProductId == Constants.ProductNames.BuyLivesSmall);
+                var medProduct = products.Single(x => x.ProductId == Constants.ProductNames.BuyLivesMedium);
+                var largeProduct = products.Single(x => x.ProductId == Constants.ProductNames.BuyLivesLarge);
+
+                _productTextBoxMapping[Constants.ProductNames.BuyLivesSmall].ButtonLabel.Text = string.Format(buttonTextFormatString, Constants.LivesPerProduct.Small, smallProduct.PriceString);
+                _productTextBoxMapping[Constants.ProductNames.BuyLivesMedium].ButtonLabel.Text = string.Format(buttonTextFormatString, Constants.LivesPerProduct.Medium, medProduct.PriceString);
+                _productTextBoxMapping[Constants.ProductNames.BuyLivesLarge].ButtonLabel.Text = string.Format(buttonTextFormatString, Constants.LivesPerProduct.Large, largeProduct.PriceString);
+
+                _productTextBoxMapping[Constants.ProductNames.BuyLivesSmall].SavePctLabel.Text = smallProduct.SavePctString;
+                _productTextBoxMapping[Constants.ProductNames.BuyLivesMedium].SavePctLabel.Text = medProduct.SavePctString;
+                _productTextBoxMapping[Constants.ProductNames.BuyLivesLarge].SavePctLabel.Text = largeProduct.SavePctString;
+
+            }
         }
 
         public override void OnDeActivate()
@@ -99,6 +154,7 @@ namespace GameLogic.LogicProviders.MenuLogicProviders
             _pnlGetMoreLives.SetActive(false);
         }
 
+        //todo: this needs to be removed, right? no longer planning to use this
         public void OnPricesLoaded(List<ProductInfoViewModel> products)
         {
 

--- a/Assets/GameLogic/LogicProviders/MenuLogicProviders/GetMoreLivesLogicProvider.cs
+++ b/Assets/GameLogic/LogicProviders/MenuLogicProviders/GetMoreLivesLogicProvider.cs
@@ -1,6 +1,8 @@
-﻿using ThirdEyeSoftware.GameLogic;
+﻿using System.Collections.Generic;
+using ThirdEyeSoftware.GameLogic;
 using ThirdEyeSoftware.GameLogic.LogicHandlers;
 using ThirdEyeSoftware.GameLogic.LogicProviders;
+using ThirdEyeSoftware.GameLogic.StoreLogicService;
 
 namespace GameLogic.LogicProviders.MenuLogicProviders
 {
@@ -95,6 +97,11 @@ namespace GameLogic.LogicProviders.MenuLogicProviders
         public override void OnDeActivate()
         {
             _pnlGetMoreLives.SetActive(false);
+        }
+
+        public void OnPricesLoaded(List<ProductInfoViewModel> products)
+        {
+
         }
     }
 }

--- a/Assets/GameLogic/StoreLogicService/StoreLogicService.cs
+++ b/Assets/GameLogic/StoreLogicService/StoreLogicService.cs
@@ -11,6 +11,8 @@ namespace ThirdEyeSoftware.GameLogic.StoreLogicService
         void OnAppStorePurchaseSucceeded(string productId);
         Action<string> LogToDebugOutput { get; set; }
         List<string> ValidateProducts(List<ProductInfo> products);
+        void OnProductsLoaded(List<ProductInfo> validatedProducts);
+        Action<List<ProductInfoViewModel>> OnProductsConverted { get; set; }
     }
 
     public class StoreLogicService : IStoreLogicService
@@ -57,13 +59,19 @@ namespace ThirdEyeSoftware.GameLogic.StoreLogicService
             set;
         }
 
+        public Action<List<ProductInfoViewModel>> OnProductsConverted
+        {
+            get;
+            set;
+        }
+
         public void OnAppStorePurchaseSucceeded(string productId)
         {
             //todo real game: extract method: SaveAdState: 
             try
             {
                 //LogToDebugOutput("StoreLogicService.OnAppStorePurchaseSucceeded()");
-
+                
                 switch (productId)
                 {
                     case Constants.ProductNames.BuyLivesSmall:
@@ -88,6 +96,11 @@ namespace ThirdEyeSoftware.GameLogic.StoreLogicService
         public List<string> ValidateProducts(List<ProductInfo> products)
         {
             return null;
+        }
+
+        public void OnProductsLoaded(List<ProductInfo> validatedProducts)
+        {
+            
         }
     }
 }

--- a/Assets/GameLogic/StoreLogicService/StoreLogicService.cs
+++ b/Assets/GameLogic/StoreLogicService/StoreLogicService.cs
@@ -10,6 +10,7 @@ namespace ThirdEyeSoftware.GameLogic.StoreLogicService
         IDataLayer DataLayer { get; set; }
         void OnAppStorePurchaseSucceeded(string productId);
         Action<string> LogToDebugOutput { get; set; }
+        List<string> ValidateProducts(List<ProductInfo> products);
     }
 
     public class StoreLogicService : IStoreLogicService
@@ -82,6 +83,11 @@ namespace ThirdEyeSoftware.GameLogic.StoreLogicService
 
                 throw;
             }
+        }
+
+        public List<string> ValidateProducts(List<ProductInfo> products)
+        {
+            return null;
         }
     }
 }

--- a/Assets/GameLogic/StoreLogicService/StoreLogicService.cs
+++ b/Assets/GameLogic/StoreLogicService/StoreLogicService.cs
@@ -16,6 +16,11 @@ namespace ThirdEyeSoftware.GameLogic.StoreLogicService
     {
         private static readonly StoreLogicService _instance = new StoreLogicService();
 
+        private ProductInfo FindSmallestProductInfo(List<ProductInfo> productInfos)
+        {
+            return null;
+        }
+
         private decimal CalculateSavePercent(ProductInfo smallPackage, ProductInfo bulkPackage)
         {
             throw new NotImplementedException();

--- a/GameLogicTest/GameControllerTest.cs
+++ b/GameLogicTest/GameControllerTest.cs
@@ -96,6 +96,31 @@ namespace GameLogicTest
         }
 
         [TestMethod]
+        public void OnStart_SetOnAppStoreInitialized()
+        {
+            //setup
+            //todo: dup mocking code. move common code to TestInitialize()
+            var gameController = GameController.Instance;
+
+            var gameEngineInterface = Substitute.For<IGameEngineInterface>();
+            gameEngineInterface.AppStoreService = Substitute.For<IAppStoreService>();
+            gameEngineInterface.AppStoreService.OnPurchaseSucceededEventHandler = null;
+            gameEngineInterface.AppStoreService.OnAppStoreInitialized = null;
+
+            var storeLogicService = Substitute.For<IStoreLogicService>();
+            storeLogicService.DataLayer = null;
+
+            var dataLayer = Substitute.For<IDataLayer>();
+            gameController.CurLevel = new LevelInfo(3, 1);
+
+            //run
+            gameController.OnStart(gameEngineInterface, dataLayer, storeLogicService);
+
+            //assert
+            Assert.IsNotNull(gameEngineInterface.AppStoreService.OnAppStoreInitialized);
+        }
+
+        [TestMethod]
         public void OnUpdate_ShouldUpdate()
         {
             #region arrange

--- a/GameLogicTest/GameControllerTest.cs
+++ b/GameLogicTest/GameControllerTest.cs
@@ -23,6 +23,16 @@ namespace GameLogicTest
         {
             //todo: need to be able to clear all properties (can't  re-instantiate since it's singleton)
             //      * maybe re-evaluate to see if this really needs to be singleton
+            _gameController = GameController.Instance;
+        }
+
+        [TestMethod]
+        public void OnProductsConvertedHandler()
+        {
+            var productsForUI = new List<ProductInfoViewModel>();
+            CallPrivateMethod(_gameController, "OnProductsConvertedHandler", new object[] { productsForUI });
+
+            Assert.AreEqual(productsForUI, _gameController.ProductsForUI);
         }
 
         [TestMethod]
@@ -120,6 +130,31 @@ namespace GameLogicTest
             Assert.IsNotNull(gameEngineInterface.AppStoreService.OnAppStoreInitialized);
         }
 
+        [TestMethod]
+        public void OnStart_SetOnProductsConverted()
+        {
+            //setup
+            //todo: dup mocking code. move common code to TestInitialize()
+            var gameController = GameController.Instance;
+
+            var gameEngineInterface = Substitute.For<IGameEngineInterface>();
+            gameEngineInterface.AppStoreService = Substitute.For<IAppStoreService>();
+            gameEngineInterface.AppStoreService.OnPurchaseSucceededEventHandler = null;
+            gameEngineInterface.AppStoreService.OnAppStoreInitialized = null;
+
+            var storeLogicService = Substitute.For<IStoreLogicService>();
+            storeLogicService.DataLayer = null;
+            storeLogicService.OnProductsConverted = null;
+
+            var dataLayer = Substitute.For<IDataLayer>();
+            gameController.CurLevel = new LevelInfo(3, 1);
+
+            //run
+            gameController.OnStart(gameEngineInterface, dataLayer, storeLogicService);
+
+            //assert
+            Assert.IsNotNull(storeLogicService.OnProductsConverted);
+        }
         [TestMethod]
         public void OnUpdate_ShouldUpdate()
         {

--- a/GameLogicTest/LogicProviders/MenuLogicProviders/GetMoreLivesLogicProviderTest.cs
+++ b/GameLogicTest/LogicProviders/MenuLogicProviders/GetMoreLivesLogicProviderTest.cs
@@ -76,7 +76,7 @@ namespace GameLogicTest.LogicProviders.MenuLogicProviders
             var txtDebugOutputGameObject = Substitute.For<IGameObject>();
             _txtDebugOutput = Substitute.For<IText>();
             txtDebugOutputGameObject.GetComponent<IText>().Returns(_txtDebugOutput);
-            _gameEngineInterface.FindGameObject("txtDebutOutput").Returns(txtDebugOutputGameObject);
+            _gameEngineInterface.FindGameObject("txtDebugOutput").Returns(txtDebugOutputGameObject);
 
             _buttonAndSaveLabels[Constants.ProductNames.BuyLivesSmall] = new Tuple<IText, IText>(Substitute.For<IText>(), Substitute.For<IText>());
             _btnBuyLivesSmall.GetComponent<IText>().Returns(_buttonAndSaveLabels[Constants.ProductNames.BuyLivesSmall].Item1);
@@ -123,6 +123,27 @@ namespace GameLogicTest.LogicProviders.MenuLogicProviders
         public void OnActivate()
         {
             //init:
+            _gameController.ProductsForUI.Returns(new List<ProductInfoViewModel>
+            {
+                new ProductInfoViewModel
+                {
+                    PriceString = "$0.99",
+                    ProductId = Constants.ProductNames.BuyLivesSmall,
+                    SavePctString = string.Empty
+                },
+                new ProductInfoViewModel
+                {
+                    PriceString = "$1.99",
+                    ProductId = Constants.ProductNames.BuyLivesMedium,
+                    SavePctString = "SAVE 30%"
+                },
+                new ProductInfoViewModel
+                {
+                    PriceString = "$2.99",
+                    ProductId = Constants.ProductNames.BuyLivesLarge,
+                    SavePctString = "SAVE 40%"
+                },
+            });
             _getMoreLivesLogicProvider.OnStart();
 
             //call:
@@ -139,6 +160,7 @@ namespace GameLogicTest.LogicProviders.MenuLogicProviders
         public void OnActivate_ProductsEmpty()
         {
             //init:
+            _gameController.ProductsForUI.Returns(new List<ProductInfoViewModel>());
             _getMoreLivesLogicProvider.OnStart();
 
             //re-do mock, change the value for error case:
@@ -156,6 +178,7 @@ namespace GameLogicTest.LogicProviders.MenuLogicProviders
         public void OnActivate_ProductsNull()
         {
             //init:
+            _gameController.ProductsForUI.Returns((List<ProductInfoViewModel>)null);
             _getMoreLivesLogicProvider.OnStart();
 
             //re-do mock, change the value for error case:

--- a/GameLogicTest/StoreLogicServiceTest/StoreLogicServiceTest.cs
+++ b/GameLogicTest/StoreLogicServiceTest/StoreLogicServiceTest.cs
@@ -254,5 +254,45 @@ namespace GameLogicTest.StoreLogicServiceTest
 
             _dataLayer.DidNotReceive().IncrementNumLivesRemaining(Arg.Any<int>());
         }
+
+        [TestMethod]
+        public void OnProductsLoaded()
+        {
+            var validatedProducts = new List<ProductInfo>
+            {
+                new ProductInfo { Price = 0.99M, PriceString = "$0.99", ProductId = Constants.ProductNames.BuyLivesSmall },
+                new ProductInfo { Price = 1.99M, PriceString = "$1.99", ProductId = Constants.ProductNames.BuyLivesMedium },
+                new ProductInfo { Price = 2.99M, PriceString = "$2.99", ProductId = Constants.ProductNames.BuyLivesLarge },
+            };
+            var expectedSaveStrings = new string[] { string.Empty, "SAVE 32%", "SAVE 45%" };
+
+            Assert.AreEqual(3, validatedProducts.Count); //check for correct test setup
+            Assert.AreEqual(validatedProducts.Count, expectedSaveStrings.Length); //check for correct test setup
+
+            _storeLogicService.OnProductsConverted = viewModels =>
+            {
+                Assert.IsNotNull(viewModels);
+                Assert.AreEqual(validatedProducts.Count, viewModels.Count);
+
+                for(var i=0; i<viewModels.Count; i++)
+                {
+                    var curViewModel = viewModels[i];
+                    var curExpectedSaveString = expectedSaveStrings[i];
+
+                    Assert.IsNotNull(curViewModel);
+                    Assert.AreEqual(curViewModel.ProductId, curViewModel.ProductId);
+                    Assert.AreEqual(curViewModel.PriceString, curViewModel.PriceString);
+                    Assert.AreEqual(curExpectedSaveString, curViewModel.SavePctString);
+                }
+            };
+
+            _storeLogicService.OnProductsLoaded(validatedProducts);
+
+            Assert.AreEqual(Constants.LivesPerProduct.Small, validatedProducts[0].Quantity);
+            Assert.AreEqual(Constants.LivesPerProduct.Medium, validatedProducts[1].Quantity);
+            Assert.AreEqual(Constants.LivesPerProduct.Large, validatedProducts[2].Quantity);
+
+            _storeLogicService.OnProductsConverted.ReceivedWithAnyArgs(1);
+        }
     }
 }

--- a/GameLogicTest/StoreLogicServiceTest/StoreLogicServiceTest.cs
+++ b/GameLogicTest/StoreLogicServiceTest/StoreLogicServiceTest.cs
@@ -82,10 +82,10 @@ namespace GameLogicTest.StoreLogicServiceTest
         }
 
         [TestMethod]
-        public void GenerateSavePctString_Success()
+        public void GenerateSavePctString()
         {
             var inputs = new[]          { 45M,   60.1M, 35.9M };
-            var expectedOutputs = new[] { "45%", "60%", "35%" };
+            var expectedOutputs = new[] { "SAVE 45%", "SAVE 60%", "SAVE 35%" };
 
             if (inputs.Length != expectedOutputs.Length)
                 Assert.Fail("UT is set up incorrectly - number of inputs does not match number of expected outputs");
@@ -95,8 +95,8 @@ namespace GameLogicTest.StoreLogicServiceTest
                 var curInput = inputs[i];
                 var curExpectedOutput = expectedOutputs[i];
 
-                CallPrivateMethod(_storeLogicService, "GenerateSavePctString", new object[] { curInput });
-                Assert.AreEqual(curExpectedOutput, curInput);
+                var actualOutput = CallPrivateMethod<string>(_storeLogicService, "GenerateSavePctString", new object[] { curInput });
+                Assert.AreEqual(curExpectedOutput, actualOutput);
             }
         }
 

--- a/GameLogicTest/StoreLogicServiceTest/StoreLogicServiceTest.cs
+++ b/GameLogicTest/StoreLogicServiceTest/StoreLogicServiceTest.cs
@@ -15,6 +15,8 @@ namespace GameLogicTest.StoreLogicServiceTest
     {
         private StoreLogicService _storeLogicService;
         private IDataLayer _dataLayer;
+        private const string VALIDATE_PRODUCTS_MISSING = "missing";
+        private const string VALIDATE_PRODUCTS_EXTRA = "extra";
 
         [TestInitialize]
         public void TestInitialize()
@@ -23,6 +25,74 @@ namespace GameLogicTest.StoreLogicServiceTest
 
             _dataLayer = Substitute.For<IDataLayer>();
             _storeLogicService.DataLayer = _dataLayer;
+        }
+
+        [TestMethod]
+        public void ValidateProducts_Success()
+        {
+            var products = new List<ProductInfo>()
+            {
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesLarge },
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesMedium},
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesSmall }
+            };
+
+            var results = _storeLogicService.ValidateProducts(products);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(0, results.Count);
+        }
+
+        [TestMethod]
+        public void ValidateProducts_Missing()
+        {
+            var products = new List<ProductInfo>()
+            {
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesLarge },
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesMedium},
+            };
+
+            var results = _storeLogicService.ValidateProducts(products);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(1, results.Count);
+            Assert.IsTrue(results[0].Contains(VALIDATE_PRODUCTS_MISSING));
+        }
+
+        [TestMethod]
+        public void ValidateProducts_Extra()
+        {
+            var products = new List<ProductInfo>()
+            {
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesLarge },
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesMedium},
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesSmall },
+                new ProductInfo { ProductId = "fake product" },
+            };
+
+            var results = _storeLogicService.ValidateProducts(products);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(1, results.Count);
+            Assert.IsTrue(results[0].Contains(VALIDATE_PRODUCTS_MISSING));
+        }
+
+        [TestMethod]
+        public void ValidateProducts_MissingAndExtra()
+        {
+            var products = new List<ProductInfo>()
+            {
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesLarge },
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesMedium},
+                new ProductInfo { ProductId = "fake product" },
+            };
+
+            var results = _storeLogicService.ValidateProducts(products);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(2, results.Count);
+            Assert.AreEqual(1, results.Count(x => x.Contains(VALIDATE_PRODUCTS_MISSING)));
+            Assert.AreEqual(1, results.Count(x => x.Contains(VALIDATE_PRODUCTS_EXTRA)));
         }
 
         [TestMethod]

--- a/GameLogicTest/StoreLogicServiceTest/StoreLogicServiceTest.cs
+++ b/GameLogicTest/StoreLogicServiceTest/StoreLogicServiceTest.cs
@@ -26,6 +26,37 @@ namespace GameLogicTest.StoreLogicServiceTest
         }
 
         [TestMethod]
+        public void FindSmallestProductInfo_Success()
+        {
+            var smallProductInfo = new ProductInfo { ProductId = Constants.ProductNames.BuyLivesSmall };
+
+            var productInfos = new List<ProductInfo>()
+            {
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesLarge },
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesMedium },
+                smallProductInfo,
+            };
+
+            var result = CallPrivateMethod<ProductInfo>(_storeLogicService, "FindSmallestProductInfo", new object[] { productInfos });
+
+            Assert.AreEqual(smallProductInfo, result);
+        }
+
+        [TestMethod]
+        public void FindSmallestProductInfo_NotFound()
+        {
+            var productInfos = new List<ProductInfo>()
+            {
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesLarge },
+                new ProductInfo { ProductId = Constants.ProductNames.BuyLivesMedium },
+            };
+
+            Action testFn = () => CallPrivateMethod<ProductInfo>(_storeLogicService, "FindSmallestProductInfo", new object[] { productInfos });
+
+            Assert.ThrowsException<InvalidOperationException>(testFn);
+        }
+
+        [TestMethod]
         public void CalculateSavePercent_FiftyPercent()
         {
             var smallProduct = new ProductInfo { Price = 1M, Quantity = 1 };


### PR DESCRIPTION
Initially, you were stuck with a compile error, because I had accidentally referenced UnityEngine.Mathf.Clamp in the CommonGameLogic project.

As a temp fix, I told you to just comment those lines out.

Now, I've provided the real fix. (See AsteroidPlacementLogicImplementer.cs). Unfortunatley, we now have a merge conflict because you've also changed those same lines of code. Next time we meet, I can show you how to resolve the conflict. (You'll get my latest changes, and tell GitHub it's okay to overwrite the lines you commented out).