### PR TITLE
Projects/1 dynamic prices (#27)

### DIFF
--- a/Assets/GameLogic/StoreLogicService/StoreLogicService.cs
+++ b/Assets/GameLogic/StoreLogicService/StoreLogicService.cs
@@ -19,19 +19,36 @@ namespace ThirdEyeSoftware.GameLogic.StoreLogicService
     {
         private static readonly StoreLogicService _instance = new StoreLogicService();
 
-        private ProductInfo FindSmallestProductInfo(List<ProductInfo> productInfos)
+        private ProductInfo FindSmallestProductInfo (List<ProductInfo>productInfos)
         {
-            return null;
+              return null;
         }
 
         private decimal CalculateSavePercent(ProductInfo smallPackage, ProductInfo bulkPackage)
         {
-            throw new NotImplementedException();
+            decimal smallBulkPrice = smallPackage.Price / smallPackage.Quantity * bulkPackage.Quantity;
+            decimal bulkPrice = bulkPackage.Price;
+            decimal packagePrice = bulkPrice / smallBulkPrice;
+            decimal priceSaved = (1 - packagePrice) * 100;
+            decimal retVal = priceSaved;
+            return retVal;
+           
         }
 
         private string GenerateSavePctString(decimal savePct)
         {
-            throw new NotImplementedException();
+            string retVal;
+            if (savePct <= 0) 
+            {
+                retVal = string.Empty;
+            } 
+            else 
+            {
+                retVal =  $"SAVE { Math.Truncate(savePct)}%";
+            }
+
+            return retVal;
+                       
         }
 
         private void SetProductQuantity(List<ProductInfo> products)
@@ -103,4 +120,5 @@ namespace ThirdEyeSoftware.GameLogic.StoreLogicService
             
         }
     }
+    
 }

--- a/GameLogicTest/LogicProviders/MenuLogicProviders/GetMoreLivesLogicProviderTest.cs
+++ b/GameLogicTest/LogicProviders/MenuLogicProviders/GetMoreLivesLogicProviderTest.cs
@@ -234,6 +234,20 @@ namespace GameLogicTest.LogicProviders.MenuLogicProviders
             _logicHandler.Received(1).SetSceneState((int)MenuState.InMenu);
         }
 
+        [TestMethod]
+        public void OnPricesLoaded()
+        {
+            _getMoreLivesLogicProvider.OnStart();
+
+            var products = new List<ProductInfoViewModel>()
+            {
+                new ProductInfoViewModel { ProductId = Constants.ProductNames.BuyLivesSmall, PriceString = "$0.99", SavePctString = string.Empty },
+                new ProductInfoViewModel { ProductId = Constants.ProductNames.BuyLivesMedium, PriceString = "$1.99", SavePctString = "SAVE 30%" },
+                new ProductInfoViewModel { ProductId = Constants.ProductNames.BuyLivesLarge, PriceString = "$2.99", SavePctString = "SAVE 40%" },
+            };
+            _getMoreLivesLogicProvider.OnPricesLoaded(products);
+        }
+
         private void AssertPriceLabelsAreCorrect()
         {
             var buttonTextFormatString = @"{0}

--- a/GameLogicTest/StoreLogicServiceTest/StoreLogicServiceTest.cs
+++ b/GameLogicTest/StoreLogicServiceTest/StoreLogicServiceTest.cs
@@ -150,7 +150,8 @@ namespace GameLogicTest.StoreLogicServiceTest
             var result = CallPrivateMethod<decimal>(_storeLogicService, "CalculateSavePercent", new object[] { smallProduct, bulkProduct });
 
             var expectedResult = (1M / 3M) * 100;
-            Assert.AreEqual(50M, result);
+            Assert.AreEqual(expectedResult, result);
+            // was Assert.AreEqual(50M, result); now gives a correct result
         }
 
         [TestMethod]
@@ -180,6 +181,41 @@ namespace GameLogicTest.StoreLogicServiceTest
             var result = CallPrivateMethod<decimal>(_storeLogicService, "CalculateSavePercent", new object[] { smallProduct, bulkProduct });
 
             Assert.AreEqual(-100M, result);
+        }
+
+        [TestMethod]
+        public void CalculateSavePercent_DifferentQuantity()
+        {
+            var smallProduct = new ProductInfo { Price = 1M, Quantity = 3 };
+            var bulkProduct = new ProductInfo { Price = 5M, Quantity = 50 };
+
+            var result = CallPrivateMethod<decimal>(_storeLogicService, "CalculateSavePercent", new object[] { smallProduct, bulkProduct });
+
+            Assert.AreEqual(70M, result);
+        }
+
+        [TestMethod]
+        public void CalculateSavePercent_DecimalPricesMedium()
+        {
+            var smallProduct = new ProductInfo { Price = 0.99M, Quantity = 10 };
+            var bulkProduct = new ProductInfo { Price = 1.99M, Quantity = 30 };
+            decimal calculation = (1M - (1.99M / (0.99M/10*30))) * 100M;
+
+            var result = CallPrivateMethod<decimal>(_storeLogicService, "CalculateSavePercent", new object[] { smallProduct, bulkProduct });
+            
+            Assert.AreEqual(calculation, result);
+        }
+
+        [TestMethod]
+        public void CalculateSavePercent_DecimalPricesLarge()
+        {
+            var smallProduct = new ProductInfo { Price = 0.99M, Quantity = 10 };
+            var bulkProduct = new ProductInfo { Price = 2.99M, Quantity = 55 };
+            decimal calculation = (1M - (2.99M / (0.99M/10*55))) * 100M;
+
+            var result = CallPrivateMethod<decimal>(_storeLogicService, "CalculateSavePercent", new object[] { smallProduct, bulkProduct });
+
+            Assert.AreEqual(calculation, result);
         }
 
         [TestMethod]


### PR DESCRIPTION
Pushing latest version

* Projects/1 dynamic prices (#1)

* fixing UT of GenerateSavePctString (#16)

original UT did not assert against returned value. it asserted that the input matched the expected output, which doesn't make any sense.

Co-authored-by: Jayd <jaydpather@gmail.com>

* UT for FindSmallestProductInfo (#17)

Co-authored-by: Jayd <jaydpather@gmail.com>

* UT for StoreLogicService.ValidateProducts (#18)

Co-authored-by: Jayd <jaydpather@gmail.com>

* UT for UpdateButtonTextAndSavePct (#22)

* UT for UpdateButtonTextAndSavePct

Co-authored-by: Jayd <jaydpather@gmail.com>

Co-authored-by: Jayd <jaydpather@gmail.com>

* Update StoreLogicService.cs

* CalculateSavePercent method adjusted, GenerateSavePctString adjusted. Corrected testmethod for GenerateSavePctString

CalculateSavePercent, adjusted so the calculations are per line of code.
GenerateSavePctString, removed console.writeline and put math.truncate at the correct place.
GenerateSavePctString for one third, adjusted the expected result from 50M to expectedResult.

* Adjusted after comments

* Smal qualities of life + extra unit test

* Fixed CalculateSavePercent and added 2 UTs to confirm

Co-authored-by: Third Eye Software <jkp.thirdeyesoftware@gmail.com>
Co-authored-by: Jayd <jaydpather@gmail.com>